### PR TITLE
Add dependabot config for composer dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+- package-ecosystem: composer
+  directory: "/"
+  schedule:
+    interval: weekly
+    timezone: America/Los_Angeles
+    day: thursday
+  open-pull-requests-limit: 99


### PR DESCRIPTION
We really only care about major release changes, as the `composer.json` config allows projects using this repository to update minor versions on their own. This should help notify us as they appear and we can decide to merge as needed.