### PR TITLE
Remove PHPCS `basepath` flag

### DIFF
--- a/HappyPrime/ruleset.xml
+++ b/HappyPrime/ruleset.xml
@@ -8,9 +8,6 @@
 	<!-- Show progress and sniff codes in all reports -->
 	<arg value="ps"/>
 
-	<!-- Strip the file paths down to the relevant bit -->
-	<arg name="basepath" value="./"/>
-
 	<!-- Add colors to the output -->
 	<arg name="colors"/>
 


### PR DESCRIPTION
This causes issues with `phpcbf` downstream and doesn't actually appear to improve filenames in the report anyway. /shrug