### PR TITLE
Rely on PHPStan for comment type hints

### DIFF
--- a/HappyPrime/ruleset.xml
+++ b/HappyPrime/ruleset.xml
@@ -33,6 +33,11 @@
 		<exclude name="Universal.Arrays.DisallowShortArraySyntax.Found"/>
 	</rule>
 
+	<rule ref="Squiz.Commenting.FunctionComment">
+		<!-- Rely on PHPStan for type hints that PHPCS may not recognize. -->
+		<exclude name="Squiz.Commenting.FunctionComment.IncorrectTypeHint" />
+	</rule>
+
 	<rule ref="WordPress.Files.FileName">
 		<!-- Some projects have an `_` in the post type slug and classic theme template files
 		     require that the slug match. This is non-consequential. -->


### PR DESCRIPTION
PHPCS seems to have trouble accepting certain type hints in comments that PHPStan seems to enjoy.