### PR TITLE
Enable no-lonely-if ESLint rule

### DIFF
--- a/eslint-config/index.js
+++ b/eslint-config/index.js
@@ -66,6 +66,7 @@ export default [
 		},
 		rules: {
 			'no-console': ['warn', { allow: ['error'] }],
+			'no-lonely-if': 'error',
 			'jsdoc/no-undefined-types': 'off',
 			'jsdoc/tag-lines': [
 				'error',
@@ -90,6 +91,7 @@ export default [
 		},
 		rules: {
 			'no-console': ['warn', { allow: ['error'] }],
+			'no-lonely-if': 'error',
 			'jsdoc/no-undefined-types': 'off',
 			'jsdoc/tag-lines': [
 				'error',


### PR DESCRIPTION
Add the no-lonely-if rule set to error for both JS/MJS and CJS file configurations to enforce that if statements inside else blocks are converted to else-if statements.