### PR TITLE
Move PHPCompatibility onto the 10.0 alpha line for 1.0.0-alpha1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,6 @@ First tagged release. Prior consumers tracked `dev-trunk`.
 
 ### Changed
 
-- Raise the PHP floor to `>=8.0`, up from `>=7.4`, and move the ruleset's
-  `testVersion` from `7.4-` to `8.0-` to match. Nothing in the dependency tree forced
-  this; the stack resolves identically on 7.4. The visible effect is that
-  PHPCompatibility no longer reports PHP 8.0 syntax — `match`, named arguments,
-  constructor property promotion, the nullsafe operator, union types — as errors.
-  A project still deploying to PHP 7.4 must set `testVersion` back to `7.4-` in its own
-  ruleset or it loses that check silently.
 - Move the PHPCompatibility stack onto its 10.0 alpha line:
   `phpcompatibility/php-compatibility` `^10.0@dev`,
   `phpcompatibility/phpcompatibility-wp` `^3.0@dev`, and a now-explicit
@@ -51,8 +44,9 @@ First tagged release. Prior consumers tracked `dev-trunk`.
 - Requires `"minimum-stability": "dev"` and `"prefer-stable": true` in your root
   `composer.json`. A transitive `@dev` constraint is not a stability flag. See the
   README.
-- Requires PHP 8.0. `phpunit/phpunit` stays at `^9.6`: phpunit 10.5 needs PHP 8.1, so
-  an 8.0 floor does not unlock it.
+- `php` stays at `>=7.4` and `testVersion` stays at `7.4-`. Nothing in the alpha line
+  forces a bump — PHPCompatibility 10 requires PHP `>=5.4` and PHPStan 2 requires
+  `^7.4 || ^8.0`.
 - PHPCompatibility 10 adds ~65 sniffs for PHP 8.1-8.5 and renames or removes six.
   Project rulesets that `<exclude>` individual PHPCompatibility sniffs need updating;
   an `<exclude>` for a sniff that no longer exists is ignored, so the rule silently

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+This project adheres to [Semantic Versioning](https://semver.org/).
+
+## [1.0.0-alpha1] - 2026-08-13
+
+First tagged release. Prior consumers tracked `dev-trunk`.
+
+### Changed
+
+- Move the PHPCompatibility stack onto its 10.0 alpha line:
+  `phpcompatibility/php-compatibility` `^10.0@dev`,
+  `phpcompatibility/phpcompatibility-wp` `^3.0@dev`, and a now-explicit
+  `phpcompatibility/phpcompatibility-paragonie` `^2.0@dev`. These have real dist zips,
+  which retires the inline `package` repository pinning a `develop` commit as
+  `9.99.9` — the git-source install that could silently go missing and take the whole
+  lint run down with `Referenced sniff "PHPCompatibility.<...>" does not exist`.
+- Replace every `*` version constraint with a caret range. A `*` let a downstream
+  `composer update` pull a new major into the ruleset without warning.
+- Require `squizlabs/php_codesniffer` explicitly at `^3.13.3` instead of inheriting it
+  transitively. `^3.13.3` is the floor PHPCompatibility 10 sets; the 3.x ceiling is
+  what WPCS 3.4 supports.
+- Upgrade the PHPStan stack to 2.x: `phpstan/phpstan` `^2.1`,
+  `phpstan/phpstan-phpunit` `^2.0`, `szepeviktor/phpstan-wordpress` `^2.0`,
+  `phpstan/extension-installer` `^1.4`.
+- `phpstan.neon.dist`: `excludePaths` entries are now fnmatch patterns
+  (`.../vendor/*`, `.../node_modules/*`). PHPStan 2 validates `excludePaths` and aborts
+  on a path that does not exist, which broke projects with no `node_modules`.
+- Bump `wp-coding-standards/wpcs` to `^3.4` and
+  `sirbrillig/phpcs-variable-analysis` to `^2.12`.
+
+### Added
+
+- Require `php-stubs/wordpress-stubs` (`^6.8`) directly. `phpstan.neon.dist` has always
+  scanned it by path but relied on `szepeviktor/phpstan-wordpress` to pull it in.
+- `README.md` with install instructions, the `minimum-stability` requirement for the
+  alpha, and the PHPCompatibility 9 -> 10 sniff rename table.
+- This changelog.
+
+### Notes for consumers
+
+- Requires `"minimum-stability": "dev"` and `"prefer-stable": true` in your root
+  `composer.json`. A transitive `@dev` constraint is not a stability flag. See the
+  README.
+- `php` stays at `>=7.4` and `testVersion` stays at `7.4-`. Nothing in the alpha line
+  forces a bump — PHPCompatibility 10 requires PHP `>=5.4` and PHPStan 2 requires
+  `^7.4 || ^8.0`.
+- PHPCompatibility 10 adds ~65 sniffs for PHP 8.1-8.5 and renames or removes six.
+  Project rulesets that `<exclude>` individual PHPCompatibility sniffs need updating;
+  an `<exclude>` for a sniff that no longer exists is ignored, so the rule silently
+  comes back on.
+
+[1.0.0-alpha1]: https://github.com/happyprime/coding-standards/releases/tag/1.0.0-alpha1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ First tagged release. Prior consumers tracked `dev-trunk`.
 
 ### Changed
 
+- Raise the PHP floor to `>=8.0`, up from `>=7.4`, and move the ruleset's
+  `testVersion` from `7.4-` to `8.0-` to match. Nothing in the dependency tree forced
+  this; the stack resolves identically on 7.4. The visible effect is that
+  PHPCompatibility no longer reports PHP 8.0 syntax — `match`, named arguments,
+  constructor property promotion, the nullsafe operator, union types — as errors.
+  A project still deploying to PHP 7.4 must set `testVersion` back to `7.4-` in its own
+  ruleset or it loses that check silently.
 - Move the PHPCompatibility stack onto its 10.0 alpha line:
   `phpcompatibility/php-compatibility` `^10.0@dev`,
   `phpcompatibility/phpcompatibility-wp` `^3.0@dev`, and a now-explicit
@@ -44,9 +51,8 @@ First tagged release. Prior consumers tracked `dev-trunk`.
 - Requires `"minimum-stability": "dev"` and `"prefer-stable": true` in your root
   `composer.json`. A transitive `@dev` constraint is not a stability flag. See the
   README.
-- `php` stays at `>=7.4` and `testVersion` stays at `7.4-`. Nothing in the alpha line
-  forces a bump — PHPCompatibility 10 requires PHP `>=5.4` and PHPStan 2 requires
-  `^7.4 || ^8.0`.
+- Requires PHP 8.0. `phpunit/phpunit` stays at `^9.6`: phpunit 10.5 needs PHP 8.1, so
+  an 8.0 floor does not unlock it.
 - PHPCompatibility 10 adds ~65 sniffs for PHP 8.1-8.5 and renames or removes six.
   Project rulesets that `<exclude>` individual PHPCompatibility sniffs need updating;
   an `<exclude>` for a sniff that no longer exists is ignored, so the rule silently

--- a/HappyPrime/ruleset.xml
+++ b/HappyPrime/ruleset.xml
@@ -12,7 +12,7 @@
 	<arg name="colors"/>
 
 	<!-- Rules: Check PHP version compatibility -->
-	<config name="testVersion" value="7.4-"/>
+	<config name="testVersion" value="8.0-"/>
 
 	<!-- Ignore 3rd party libraries loaded by NPM -->
 	<exclude-pattern>*/node_modules/*</exclude-pattern>

--- a/HappyPrime/ruleset.xml
+++ b/HappyPrime/ruleset.xml
@@ -12,7 +12,7 @@
 	<arg name="colors"/>
 
 	<!-- Rules: Check PHP version compatibility -->
-	<config name="testVersion" value="8.0-"/>
+	<config name="testVersion" value="7.4-"/>
 
 	<!-- Ignore 3rd party libraries loaded by NPM -->
 	<exclude-pattern>*/node_modules/*</exclude-pattern>

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Happy Prime projects.
 
 ## Install
 
+Requires PHP 8.0 or later.
+
 ```sh
 composer require --dev happyprime/coding-standards:^1.0@alpha
 ```
@@ -90,14 +92,31 @@ includes:
     - vendor/happyprime/coding-standards/phpstan.neon.dist
 ```
 
-`testVersion` defaults to `7.4-`. Override it in your own ruleset if the project has a
-higher floor:
+`testVersion` defaults to `8.0-`, so PHP 8.0 syntax — `match`, named arguments,
+constructor property promotion, the nullsafe operator, union types — passes clean.
+Override it in your own ruleset if the project has a different floor:
 
 ```xml
+<!-- Project targets 8.1+ and wants readonly, enums, never. -->
 <config name="testVersion" value="8.1-"/>
+
+<!-- Project still deploys to 7.4. Set this or you lose the safety net. -->
+<config name="testVersion" value="7.4-"/>
 ```
 
 ## Upgrading to 1.0.0-alpha1
+
+### PHP 8.0 floor
+
+`"php": ">=8.0"`, up from `>=7.4`. Composer will refuse to install this package on
+PHP 7.4. Nothing in the dependency tree forced this — the whole stack still resolves
+identically on 7.4 — it is a policy floor.
+
+`testVersion` moves from `7.4-` to `8.0-` to match. This is the change you will
+actually notice: PHPCompatibility stops reporting PHP 8.0 features as errors, so code
+that previously failed the lint now passes. A project that still deploys to PHP 7.4
+must set `<config name="testVersion" value="7.4-"/>` in its own ruleset, or it loses
+that check silently.
 
 ### PHPCompatibility 10 renamed sniffs
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ Happy Prime projects.
 
 ## Install
 
-Requires PHP 8.0 or later.
-
 ```sh
 composer require --dev happyprime/coding-standards:^1.0@alpha
 ```
@@ -92,31 +90,14 @@ includes:
     - vendor/happyprime/coding-standards/phpstan.neon.dist
 ```
 
-`testVersion` defaults to `8.0-`, so PHP 8.0 syntax — `match`, named arguments,
-constructor property promotion, the nullsafe operator, union types — passes clean.
-Override it in your own ruleset if the project has a different floor:
+`testVersion` defaults to `7.4-`. Override it in your own ruleset if the project has a
+higher floor:
 
 ```xml
-<!-- Project targets 8.1+ and wants readonly, enums, never. -->
 <config name="testVersion" value="8.1-"/>
-
-<!-- Project still deploys to 7.4. Set this or you lose the safety net. -->
-<config name="testVersion" value="7.4-"/>
 ```
 
 ## Upgrading to 1.0.0-alpha1
-
-### PHP 8.0 floor
-
-`"php": ">=8.0"`, up from `>=7.4`. Composer will refuse to install this package on
-PHP 7.4. Nothing in the dependency tree forced this — the whole stack still resolves
-identically on 7.4 — it is a policy floor.
-
-`testVersion` moves from `7.4-` to `8.0-` to match. This is the change you will
-actually notice: PHPCompatibility stops reporting PHP 8.0 features as errors, so code
-that previously failed the lint now passes. A project that still deploys to PHP 7.4
-must set `<config name="testVersion" value="7.4-"/>` in its own ruleset, or it loses
-that check silently.
 
 ### PHPCompatibility 10 renamed sniffs
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,140 @@
+# Happy Prime coding standards
+
+PHP_CodeSniffer ruleset, PHPStan config, and shared JS/CSS tooling configs used across
+Happy Prime projects.
+
+## What's in here
+
+| Path | What it is |
+| --- | --- |
+| `HappyPrime/ruleset.xml` | The `HappyPrime` phpcs standard — WPCS + PHPCompatibilityWP + VariableAnalysis |
+| `phpstan.neon.dist` | PHPStan level 1 with WordPress, WP-CLI, and test stubs pre-scanned |
+| `common-configs/` | Shared editorconfig, prettier, stylelint, postcss, webpack configs |
+| `eslint-config/`, `stylelint-config/`, `postcss-config/` | Published npm packages |
+
+## Install
+
+```sh
+composer require --dev happyprime/coding-standards:^1.0@alpha
+```
+
+The `1.0.0-alpha1` line tracks the PHPCompatibility 10 alpha, which has no stable
+release yet. Composer will refuse the install unless your root `composer.json` opts in
+to prereleases:
+
+```json
+{
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}
+```
+
+Both keys are required. `prefer-stable` keeps every other dependency on its newest
+stable release, so this does not turn your whole tree into a dev build.
+
+### If you skip that, you get this
+
+A `@dev` constraint inside a dependency is not a stability flag for your root project.
+Composer only honors stability flags declared in the root `composer.json`, so
+requiring `happyprime/coding-standards` alone fails with:
+
+```
+happyprime/coding-standards 1.0.0-alpha1 requires
+phpcompatibility/phpcompatibility-wp ^3.0@dev -> found
+phpcompatibility/phpcompatibility-wp[3.0.0-alpha1, 3.0.0-alpha2] but it does not
+match your minimum-stability.
+```
+
+Adding `minimum-stability: dev` + `prefer-stable: true` resolves it.
+
+### Drop the php-compatibility hack
+
+Projects that worked around the missing PHPCompatibility 9.x release with an inline
+`package` repository should delete it:
+
+```json
+"repositories": [
+    {
+        "type": "package",
+        "package": {
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.99.9",
+            "source": { "type": "git", "url": "...", "reference": "develop" }
+        }
+    }
+]
+```
+
+That entry has no `dist`, so Composer installs it by `git clone`. It is the only phpcs
+standard installed that way, which makes it the only one that can go missing without
+a download failure — and when it does, every rule fails with
+`ERROR: Referenced sniff "PHPCompatibility.<...>" does not exist` and the lint run
+dies. The 10.0 alphas ship real dist zips, so the hack is no longer needed.
+
+## Usage
+
+`phpcs.xml.dist`:
+
+```xml
+<?xml version="1.0"?>
+<ruleset name="Project">
+	<rule ref="HappyPrime"/>
+	<file>.</file>
+</ruleset>
+```
+
+`phpstan.neon`:
+
+```neon
+includes:
+    - vendor/happyprime/coding-standards/phpstan.neon.dist
+```
+
+`testVersion` defaults to `7.4-`. Override it in your own ruleset if the project has a
+higher floor:
+
+```xml
+<config name="testVersion" value="8.1-"/>
+```
+
+## Upgrading to 1.0.0-alpha1
+
+### PHPCompatibility 10 renamed sniffs
+
+The `HappyPrime` ruleset references `PHPCompatibilityWP` wholesale and needs no
+changes. Project rulesets that `<exclude>` individual sniffs do — an `<exclude>` naming
+a sniff that no longer exists is silently ignored, so the rule comes back on.
+
+| PHPCompatibility 9.x | PHPCompatibility 10 |
+| --- | --- |
+| `PHPCompatibility.Classes.ForbiddenAbstractPrivateMethods` | `PHPCompatibility.FunctionDeclarations.AbstractPrivateMethods` |
+| `PHPCompatibility.Miscellaneous.ValidIntegers` | `PHPCompatibility.Numbers.ValidIntegers` |
+| `PHPCompatibility.Miscellaneous.ValidIntegers` (hex numeric string check only) | `PHPCompatibility.Numbers.RemovedHexadecimalNumericStrings` |
+| `PHPCompatibility.Keywords.ForbiddenNamesAsDeclared` | Removed — folded into `PHPCompatibility.Keywords.ForbiddenNames` |
+| `PHPCompatibility.Keywords.ForbiddenNamesAsInvokedFunctions` | Removed, no replacement |
+| `PHPCompatibility.Upgrade.LowPHPCS` | Removed, no replacement |
+
+Error codes that changed within surviving sniffs:
+
+| 9.x code | 10 code |
+| --- | --- |
+| `PHPCompatibility.TypeCasts.RemovedTypeCasts.t_unset_castDeprecatedRemoved` | `...RemovedTypeCasts.unsetDeprecatedRemoved` |
+| `PHPCompatibility.TypeCasts.RemovedTypeCasts.t_double_castDeprecatedRemoved` | `...RemovedTypeCasts.realDeprecatedRemoved` |
+| `PHPCompatibility.FunctionDeclarations.NewParamTypeDeclarations.InvalidTypeHintFound` | Split; "long" types now report `InvalidLongTypeFound` |
+| `PHPCompatibility.Classes.NewTypedProperties.InvalidType` | Split; "long" types now report `InvalidLongType` |
+
+PHPCompatibility 10 also adds ~65 new sniffs covering PHP 8.1–8.5, so expect new
+violations on code that passed under 9.3.5.
+
+### PHPStan 2
+
+`phpstan/phpstan` moved from `^1.10` to `^2.1`. PHPStan 2 validates `excludePaths` and
+errors out on a path that does not exist, which broke the shipped config on projects
+without a `node_modules` directory. The entries are now `.../vendor/*` and
+`.../node_modules/*` — fnmatch patterns, which PHPStan does not require to exist.
+
+Level 1 finds more in PHPStan 2 than in 1.x. Add a baseline if the jump is noisy:
+
+```sh
+vendor/bin/phpstan analyse --generate-baseline
+```

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		}
 	},
 	"require": {
-	  "php": ">=7.4",
+	  "php": ">=8.0",
 	  "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
 	  "squizlabs/php_codesniffer": "^3.13.3",
 	  "phpcompatibility/php-compatibility": "^10.0@dev",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		}
 	},
 	"require": {
-	  "php": ">=8.0",
+	  "php": ">=7.4",
 	  "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
 	  "squizlabs/php_codesniffer": "^3.13.3",
 	  "phpcompatibility/php-compatibility": "^10.0@dev",

--- a/composer.json
+++ b/composer.json
@@ -10,20 +10,23 @@
 		}
 	},
 	"require": {
-	  "dealerdirect/phpcodesniffer-composer-installer": "*",
 	  "php": ">=7.4",
-	  "phpcompatibility/phpcompatibility-wp": "*",
-	  "phpcompatibility/php-compatibility": "*",
-	  "sirbrillig/phpcs-variable-analysis": "*",
-	  "wp-coding-standards/wpcs": "*",
-	  "phpstan/phpstan": "^1.10",
-	  "szepeviktor/phpstan-wordpress": "^1.3",
-	  "phpstan/extension-installer": "^1.3",
-	  "phpstan/phpstan-phpunit": "^1.3",
-	  "php-stubs/wordpress-tests-stubs": "^6.2",
-	  "php-stubs/wp-cli-stubs": "^2.9",
-	  "phpunit/phpunit": "^5 || ^7 || ^8 || ^9",
-	  "yoast/phpunit-polyfills": "*"
+	  "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+	  "squizlabs/php_codesniffer": "^3.13.3",
+	  "phpcompatibility/php-compatibility": "^10.0@dev",
+	  "phpcompatibility/phpcompatibility-paragonie": "^2.0@dev",
+	  "phpcompatibility/phpcompatibility-wp": "^3.0@dev",
+	  "sirbrillig/phpcs-variable-analysis": "^2.12",
+	  "wp-coding-standards/wpcs": "^3.4",
+	  "phpstan/phpstan": "^2.1",
+	  "phpstan/extension-installer": "^1.4",
+	  "phpstan/phpstan-phpunit": "^2.0",
+	  "szepeviktor/phpstan-wordpress": "^2.0",
+	  "php-stubs/wordpress-stubs": "^6.8",
+	  "php-stubs/wordpress-tests-stubs": "^6.8",
+	  "php-stubs/wp-cli-stubs": "^2.12",
+	  "phpunit/phpunit": "^9.6",
+	  "yoast/phpunit-polyfills": "^4.0"
 	},
 	"suggest": {
 	  "dealerdirect/phpcodesniffer-composer-installer": "Automatically adds this package's ruleset to the installed_paths option of PHP_CodeSniffer"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,6 +9,6 @@ parameters:
       - %rootDir%/../../php-stubs/wp-cli-stubs/wp-cli-commands-stubs.php
       - %rootDir%/../../php-stubs/wp-cli-stubs/wp-cli-i18n-stubs.php
   excludePaths:
-    - %rootDir%/../../../vendor
-    - %rootDir%/../../../node_modules
+    - %rootDir%/../../../vendor/*
+    - %rootDir%/../../../node_modules/*
   ignoreErrors:


### PR DESCRIPTION
Ships the dependency changes for a `1.0.0-alpha1` tag so the PHPCompatibility hack can come out of downstream projects.

## Why

`phpcompatibility/php-compatibility` never shipped a 9.x release that works with modern PHP_CodeSniffer, so downstream projects fake one with an inline `package` repository pinning a `develop` commit as version `9.99.9`, with a git source and no dist. That makes it the only phpcs standard installed by `git clone` instead of a dist zip, and the only one that can silently go missing. When it does, every PHPCompatibilityWP rule fails with `ERROR: Referenced sniff "PHPCompatibility.<...>" does not exist` and the lint run dies.

The 10.0 line now has tagged prereleases with real dist zips. Consumers can drop the hack and just require this package.

## Changes

**PHPCompatibility onto the alpha line**

| Package | Was | Now | Resolves to |
| --- | --- | --- | --- |
| `phpcompatibility/php-compatibility` | `*` | `^10.0@dev` | 10.0.0-alpha2 |
| `phpcompatibility/phpcompatibility-wp` | `*` | `^3.0@dev` | 3.0.0-alpha2 |
| `phpcompatibility/phpcompatibility-paragonie` | transitive | `^2.0@dev` | 2.0.0-alpha2 |

**Every `*` replaced with a caret range.** A `*` let a downstream `composer update` drag a new major into the ruleset with no warning.

| Package | Was | Now | Resolves to |
| --- | --- | --- | --- |
| `squizlabs/php_codesniffer` | transitive | `^3.13.3` | 3.13.6 |
| `wp-coding-standards/wpcs` | `*` | `^3.4` | 3.4.1 |
| `sirbrillig/phpcs-variable-analysis` | `*` | `^2.12` | v2.13.0 |
| `dealerdirect/phpcodesniffer-composer-installer` | `*` | `^1.0` | v1.2.1 |
| `phpstan/phpstan` | `^1.10` | `^2.1` | 2.2.8 |
| `phpstan/phpstan-phpunit` | `^1.3` | `^2.0` | 2.0.18 |
| `szepeviktor/phpstan-wordpress` | `^1.3` | `^2.0` | v2.0.3 |
| `phpstan/extension-installer` | `^1.3` | `^1.4` | 1.4.3 |
| `php-stubs/wordpress-stubs` | transitive | `^6.8` | v6.9.4 |
| `php-stubs/wordpress-tests-stubs` | `^6.2` | `^6.8` | v6.9.5 |
| `php-stubs/wp-cli-stubs` | `^2.9` | `^2.12` | v2.12.0 |
| `phpunit/phpunit` | `^5 \|\| ^7 \|\| ^8 \|\| ^9` | `^9.6` | 9.6.36 |
| `yoast/phpunit-polyfills` | `*` | `^4.0` | 4.0.0 |

`squizlabs/php_codesniffer` is now explicit rather than transitive. `^3.13.3` is the floor PHPCompatibility 10 sets; the 3.x ceiling is what WPCS 3.4 supports. `php-stubs/wordpress-stubs` is now explicit because `phpstan.neon.dist` scans it by path but relied on `szepeviktor/phpstan-wordpress` to pull it in.

**`phpstan.neon.dist` excludePaths.** PHPStan 2 validates `excludePaths` and aborts on a path that does not exist, which broke the shipped config on any project without a `node_modules` directory:

```
Invalid entry in excludePaths:
Path ".../vendor/phpstan/phpstan/../../../node_modules" is neither a directory, nor a file path, nor a fnmatch pattern.
```

The entries are now `.../vendor/*` and `.../node_modules/*` — fnmatch patterns, which PHPStan does not require to exist. The documented `(?)` suffix does not work here: NEON parses `%rootDir%/... (?)` as an entity and PHPStan crashes with `FileExcluder::isAbsolutePath(): Argument #1 ($path) must be of type string, Statement given`.

**Unchanged.** `"php": ">=7.4"` and `<config name="testVersion" value="7.4-"/>` stay as they are. Nothing in the alpha line forces a bump — PHPCompatibility 10 requires PHP `>=5.4` and PHPStan 2 requires `^7.4 || ^8.0`.

## Consumer requirement

A transitive `@dev` constraint is not a stability flag. Consumers must set both of these in their own root `composer.json`:

```json
{
    "minimum-stability": "dev",
    "prefer-stable": true
}
```

Without them the install fails with `... but it does not match your minimum-stability`. Documented in the README with the error text.

## PHPCompatibility 9 -> 10 sniff renames

This repo's ruleset references `PHPCompatibilityWP` wholesale and needs no changes. Project rulesets that `<exclude>` individual sniffs do — an `<exclude>` naming a sniff that no longer exists is silently ignored, so the rule comes back on. Full table is in the README.

| 9.x | 10 |
| --- | --- |
| `Classes.ForbiddenAbstractPrivateMethods` | `FunctionDeclarations.AbstractPrivateMethods` |
| `Miscellaneous.ValidIntegers` | `Numbers.ValidIntegers` |
| `Miscellaneous.ValidIntegers` (hex numeric strings) | `Numbers.RemovedHexadecimalNumericStrings` |
| `Keywords.ForbiddenNamesAsDeclared` | Removed, folded into `Keywords.ForbiddenNames` |
| `Keywords.ForbiddenNamesAsInvokedFunctions` | Removed, no replacement |
| `Upgrade.LowPHPCS` | Removed, no replacement |

PHPCompatibility 10 also adds ~65 sniffs for PHP 8.1-8.5 (117 sniffs -> 176), so expect new violations on code that passed under 9.3.5.

## Verification

Scratch consumer project pulling this branch via a `vcs` repository, with `minimum-stability: dev` + `prefer-stable: true`.

All three phpcompatibility packages install from dist, not source:

```
  - Installing phpcompatibility/php-compatibility (10.0.0-alpha2): Extracting archive
  - Installing phpcompatibility/phpcompatibility-paragonie (2.0.0-alpha2): Extracting archive
  - Installing phpcompatibility/phpcompatibility-wp (3.0.0-alpha2): Extracting archive
```

dealerdirect registers all three:

```
PHP CodeSniffer Config installed_paths set to ../../happyprime/coding-standards,../../phpcompatibility/php-compatibility,../../phpcompatibility/phpcompatibility-paragonie,../../phpcompatibility/phpcompatibility-wp,../../phpcsstandards/phpcsextra,../../phpcsstandards/phpcsutils,../../sirbrillig/phpcs-variable-analysis,../../wp-coding-standards/wpcs
```

Zero `Referenced sniff` errors:

```
$ vendor/bin/phpcs --standard=vendor/happyprime/coding-standards/HappyPrime throwaway.php
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
 16 | WARNING | Unused variable $unused.
    |         | (VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable)
```

The one warning is the deliberate unused variable in the fixture.

```
$ vendor/bin/phpcs -e --standard=PHPCompatibility
The PHPCompatibility standard contains 176 sniffs
```

PHPCompatibility rules actually fire against `testVersion 7.4-` (fixture using PHP 8.1 enums):

```
FOUND 3 ERRORS AND 1 WARNING AFFECTING 2 LINES
   |         |     earlier (PHPCompatibility.Keywords.NewKeywords.t_enumFound)
```

PHPStan 2 runs clean from the consumer with no `node_modules` present:

```
$ vendor/bin/phpstan analyse --no-progress
 [OK] No errors
```

Same consumer with the old `excludePaths` form, to confirm the fix was needed:

```
Invalid entry in excludePaths:
Path ".../consumer/vendor/phpstan/phpstan/../../../node_modules" is neither a directory, nor a file path, nor a fnmatch pattern.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)